### PR TITLE
Fix chdir in bin/verbum

### DIFF
--- a/bin/verbum
+++ b/bin/verbum
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-chdir('../');
+chdir(dirname(__DIR__));
 
 require 'vendor/autoload.php';
 


### PR DESCRIPTION
Complication: the script can be run only from "bin" directory. Command "php bin/verbum" will be failed.